### PR TITLE
Save do ErrorOccurrence com DateTime.Now

### DIFF
--- a/ErrorHub.Data/Repositories/ErrorOccurrenceRepository.cs
+++ b/ErrorHub.Data/Repositories/ErrorOccurrenceRepository.cs
@@ -1,5 +1,6 @@
 ﻿using ErrorHub.Data.Context;
 using ErrorHub.Domain.Entities;
+using ErrorHub.Domain.Enuns;
 using ErrorHub.Domain.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -35,6 +36,15 @@ namespace ErrorHub.Data.Repositories
                 return user;
 
             throw new Exception($"Ocorrência de erro com id {id} não encontrada.");
+        }
+
+        public List<ErrorOccurrence> GetByEnvironment(EnvironmentOccurrence environment)
+        {
+            var result = _context.ErrorOccurrences.Where(e => e.Environment == environment);
+            if (result.Any())
+                return result.ToList();
+
+            throw new Exception("Não há ocorrências de erro cadastradas.");
         }
 
         public void Save(ErrorOccurrence errorOccurrence)

--- a/ErrorHub.Domain/Repositories/Interfaces/IErrorOccurrenceRepository.cs
+++ b/ErrorHub.Domain/Repositories/Interfaces/IErrorOccurrenceRepository.cs
@@ -1,4 +1,5 @@
 ﻿using ErrorHub.Domain.Entities;
+using ErrorHub.Domain.Enuns;
 using System.Collections.Generic;
 
 namespace ErrorHub.Domain.Repositories.Interfaces
@@ -7,6 +8,7 @@ namespace ErrorHub.Domain.Repositories.Interfaces
     {
         List<ErrorOccurrence> GetAll();
         ErrorOccurrence GetById(int id);
+        List<ErrorOccurrence> GetByEnvironment(EnvironmentOccurrence environment);
         void Save(ErrorOccurrence errorOccurrence);
         void Update(ErrorOccurrence errorOccurrence);
         void ArchiveRecord(int id);

--- a/ErrorHub.Domain/Services/ErrorOccurrenceService.cs
+++ b/ErrorHub.Domain/Services/ErrorOccurrenceService.cs
@@ -1,4 +1,5 @@
 ﻿using ErrorHub.Domain.Entities;
+using ErrorHub.Domain.Enuns;
 using ErrorHub.Domain.Repositories.Interfaces;
 using ErrorHub.Domain.Services.Interfaces;
 using System;
@@ -35,6 +36,19 @@ namespace ErrorHub.Domain.Services
             }
             catch (Exception e)
             {
+                throw e;
+            }
+        }
+
+        public IList<ErrorOccurrence> GetByEnvironment(EnvironmentOccurrence environment)
+        {
+            try
+            {
+                return _repository.GetByEnvironment(environment);
+            }
+            catch (Exception e)
+            {
+                
                 throw e;
             }
         }

--- a/ErrorHub.Domain/Services/ErrorOccurrenceService.cs
+++ b/ErrorHub.Domain/Services/ErrorOccurrenceService.cs
@@ -43,6 +43,10 @@ namespace ErrorHub.Domain.Services
         {
             try
             {
+                if(errorOccurrence.CreatedAt == DateTime.MinValue || errorOccurrence.CreatedAt == null)
+                {
+                    errorOccurrence.CreatedAt = DateTime.Now;
+                }
                 _repository.Save(errorOccurrence);
             }
             catch (Exception e)

--- a/ErrorHub.Domain/Services/Interfaces/IErrorOccurrenceService.cs
+++ b/ErrorHub.Domain/Services/Interfaces/IErrorOccurrenceService.cs
@@ -1,4 +1,5 @@
 ﻿using ErrorHub.Domain.Entities;
+using ErrorHub.Domain.Enuns;
 using System.Collections.Generic;
 
 namespace ErrorHub.Domain.Services.Interfaces
@@ -7,6 +8,7 @@ namespace ErrorHub.Domain.Services.Interfaces
     {
         IList<ErrorOccurrence> GetAll();
         ErrorOccurrence GetById(int id);
+        IList<ErrorOccurrence> GetByEnvironment(EnvironmentOccurrence environment);
         void Save(ErrorOccurrence errorOccurrence);
         void Update(ErrorOccurrence errorOccurrence);
         void ArchiveRecord(int id);

--- a/ErrorHub.WebApi/Controllers/ErrorOccurrenceController.cs
+++ b/ErrorHub.WebApi/Controllers/ErrorOccurrenceController.cs
@@ -151,7 +151,7 @@ namespace ErrosHub.WebApi.Controllers
             }
             catch (Exception e)
             {
-                throw;
+                throw e;
             }
 
             return Ok("Deleted.");

--- a/ErrorHub.WebApi/Controllers/ErrorOccurrenceController.cs
+++ b/ErrorHub.WebApi/Controllers/ErrorOccurrenceController.cs
@@ -72,6 +72,33 @@ namespace ErrosHub.WebApi.Controllers
                 return NoContent();
         }
 
+        [HttpGet("environment/{environment}")]
+        public IActionResult GetByEnvironment(string environment)
+        {
+            try
+            {
+                var environmentEnum = Enum.Parse(typeof(EnvironmentOccurrence), environment, true);
+                var recoveredList = _errorOccurrenceService.GetByEnvironment((EnvironmentOccurrence)environmentEnum);
+                var errorsList = recoveredList.Select(x => new ErrorOccurrenceVM
+                {
+                    Id = x.Id,
+                    Level = x.Level.ToString(),
+                    Environment = x.Environment.ToString(),
+                    Title = x.Title,
+                    Description = x.Description,
+                    ArchiviedRecord = x.ArchiviedRecord,
+                    Origin = x.Origin,
+                    CreatedAt = x.CreatedAt
+                });
+                return Ok(errorsList);
+                
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+
         [HttpPost]
         public IActionResult Save(ErrorOccurrenceVM errorOccurrence)
         {


### PR DESCRIPTION
Criado regra no método Save do ErrorOccurrenceService para pegar a data e hora do sistema caso não seja informado na API.